### PR TITLE
fix warnings

### DIFF
--- a/DetailManager/DetailManager.vcxproj
+++ b/DetailManager/DetailManager.vcxproj
@@ -54,7 +54,6 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;DETAILMANAGER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />

--- a/DetailManager/DetailManager.vcxproj
+++ b/DetailManager/DetailManager.vcxproj
@@ -18,12 +18,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/DetailManager/source/dllmain.cpp
+++ b/DetailManager/source/dllmain.cpp
@@ -73,8 +73,8 @@ BOOL WINAPI DllMain(
             GetModuleFileNameW(hinstDLL, fullpath, MAX_PATH);
             _wsplitpath_s(fullpath, drive, MAX_PATH, dir, MAX_PATH, 0, 0, 0, 0);
 
-            wcscpy(g_module_dir, drive);
-            wcscat(g_module_dir, dir);
+            wcscpy_s(g_module_dir, drive);
+            wcscat_s(g_module_dir, dir);
         }
 		
         break;
@@ -106,21 +106,23 @@ void WINAPI atsLoad()
         memset(g_detailmodules, 0, sizeof(ST_DETAILMODULE_ATS_DELEGATE_FUNC) * MAX_DETAILMODULE_NUM);
         memset(g_handles, 0, sizeof(ATS_HANDLES) * 2);
 
-        wcscpy(detailmodules_txt_path, g_module_dir);
-        wcscat(detailmodules_txt_path, L"\\detailmodules.txt");
+        wcscpy_s(detailmodules_txt_path, g_module_dir);
+        wcscat_s(detailmodules_txt_path, L"\\detailmodules.txt");
         
         ret = _wstat(detailmodules_txt_path, &buf);
     }
 
     if (!ret)
     {
-        FILE* fp = _wfopen(detailmodules_txt_path, L"r");
+        FILE *fp = NULL;
+        _wfopen_s(&fp, detailmodules_txt_path, L"r");
 
         while (!feof(fp))
         {
             char module_path[MAX_PATH];
             wchar_t module_full_path[MAX_PATH],
                     module_path_wcs[MAX_PATH];
+            size_t tmp = 0;
 
             memset(module_path, 0, sizeof(char) * MAX_PATH);
 
@@ -135,10 +137,10 @@ void WINAPI atsLoad()
                 }
             }
 
-            wcscpy(module_full_path, g_module_dir);
-            mbstowcs(module_path_wcs, module_path, MAX_PATH);
+            wcscpy_s(module_full_path, g_module_dir);
+            mbstowcs_s(&tmp, module_path_wcs, module_path, MAX_PATH);
 //            wcscat(module_full_path, L"..\\..\\Plugin\\");
-            wcscat(module_full_path, module_path_wcs);
+            wcscat_s(module_full_path, module_path_wcs);
 
             {
                 struct _stat buf;


### PR DESCRIPTION
## 概要

ビルド時に出力されるWarningを解消したものです.  動作に大きな影響を与えるとは思えませんが, Warningが残っている状態は気持ち悪いので, 修正を行いました.

## 実行環境

- Windows11 (Build 22543.1000)
- Visual Studio Community 2022 Preview (Version 17.1.0 Preview 5.0)
- Microsoft (R) C/C++ Optimizing Compiler Version 19.31.31104 for x86

## Warning一覧 (Debug build)

Severity|Code|Description|Project|File|Line|Suppression State
---|---|---|---|---|---|---
Warning|D9035|option 'Gm' has been deprecated and will be removed in a future release|DetailManager|C:\GitHub\DetailManager\DetailManager\cl|1|
Warning|C4996|'wcscpy': This function or variable may be unsafe. Consider using wcscpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.|DetailManager|c:\github\detailmanager\detailmanager\source\dllmain.cpp|76|
Warning|C4996|'wcscat': This function or variable may be unsafe. Consider using wcscat_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.|DetailManager|c:\github\detailmanager\detailmanager\source\dllmain.cpp|77|
Warning|C4996|'wcscpy': This function or variable may be unsafe. Consider using wcscpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.|DetailManager|c:\github\detailmanager\detailmanager\source\dllmain.cpp|109|
Warning|C4996|'wcscat': This function or variable may be unsafe. Consider using wcscat_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.|DetailManager|c:\github\detailmanager\detailmanager\source\dllmain.cpp|110|
Warning|C4996|'_wfopen': This function or variable may be unsafe. Consider using _wfopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.|DetailManager|c:\github\detailmanager\detailmanager\source\dllmain.cpp|117|
Warning|C4996|'wcscpy': This function or variable may be unsafe. Consider using wcscpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.|DetailManager|c:\github\detailmanager\detailmanager\source\dllmain.cpp|138|
Warning|C4996|'mbstowcs': This function or variable may be unsafe. Consider using mbstowcs_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.|DetailManager|c:\github\detailmanager\detailmanager\source\dllmain.cpp|139|
Warning|C4996|'wcscat': This function or variable may be unsafe. Consider using wcscat_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.|DetailManager|c:\github\detailmanager\detailmanager\source\dllmain.cpp|141|
Warning|LNK4075|ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification|DetailManager|C:\GitHub\DetailManager\DetailManager\dllmain.obj|1|

## 修正の詳細

### Code D9035 (Debug Build時のみ)

https://github.com/mikangogo/DetailManager/blob/146816e76abe733b41ad809887939f4e4ecea327/DetailManager/DetailManager.vcxproj#L57

上記`MinimalRebuild`設定の除去にて解消しました.  ビルド時間が少し延びる可能性がありますが, この規模のものであればそこまで大きな問題にはならないかと思われます.

### Code C4996

https://github.com/TetsuOtter/DetailManager/commit/0518d6ef08fd181c84cd1e2d21d5f2ad51a22889

上記のコミットにて解消を行いました.  同一コミットにて先述のCode D9035の解消も行っています

- `wcscat`関数と`wcscpy`関数については単純に関数指定を`wcscat_s`関数と`wcscpy_s`関数に変更しているだけです.
- `_wfopen`関数と`mbstowcs`関数については, `_wfopen_s`関数と`mbstowcs_s`関数に変更するにあたり, 戻り値の取得方法をアドレス渡しに変更する修正を行っています.
  - `errno`の取得については修正以前から行われていないため, この実装でも行っていません.

### Code LNK4075 (Debug Build時のみ)

https://github.com/TetsuOtter/DetailManager/commit/66b4fd3dd478f5888123d82564858f864e202e68

上記のコミットにて解消を行いました.

[「「warning LNK4075: /EDITANDCONTINUE は /SAFESEH の指定によって無視されます」の本当の対処法」](https://qiita.com/gocha/items/d690f1240813aef8b303) を参考に, `UseDebugLibraries`オプションの指定にてWarningを解消しています.

Releaseビルド用の設定を行う必要はありませんが, 対称性を持たせたほうがわかりやすいため設定を行っています.